### PR TITLE
Fixing bower warning

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "mgl-map",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "authors": [
     "Daniel Olano <daniel@olinguito.co>"
   ],


### PR DESCRIPTION
    bower checkout      mapbox-gl-map-element#v1.1.5
    bower mismatch      Version declared in the json (1.1.4) is different than the resolved one (1.1.5)